### PR TITLE
fix: support boosted V5 Opus quota

### DIFF
--- a/src/main/nai/client.ts
+++ b/src/main/nai/client.ts
@@ -41,8 +41,6 @@ export function parseSubscriptionResponse(data: NaiSubscriptionResponse): Subscr
   const validUsage =
     usage &&
     Number.isFinite(usage.percent) &&
-    usage.percent >= 0 &&
-    usage.percent <= 100 &&
     typeof usage.isNegative === 'boolean' &&
     Number.isFinite(usage.timeUntilNextPercent) &&
     usage.timeUntilNextPercent >= 0

--- a/src/renderer/src/components/token-dialog.tsx
+++ b/src/renderer/src/components/token-dialog.tsx
@@ -645,7 +645,7 @@ function AccountSection(): React.JSX.Element {
           <div className="h-2 overflow-hidden rounded-full bg-paper">
             <div
               className={cn(
-                'h-full rounded-full transition-[width] duration-300',
+                'h-full max-w-full rounded-full transition-[width] duration-300',
                 opusUsage?.isNegative ? 'bg-danger' : 'bg-accent'
               )}
               style={{ width: `${opusUsage ? displayOpusUsagePercent(opusUsage) : 0}%` }}

--- a/src/renderer/src/components/token-dialog.tsx
+++ b/src/renderer/src/components/token-dialog.tsx
@@ -15,7 +15,7 @@ import {
   Upload
 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
-import { displayOpusUsagePercent } from '@shared/anlas'
+import { displayOpusUsagePercent, opusUsagePercentSegments } from '@shared/anlas'
 import discordSvg from '../assets/discord.svg'
 import nais3Logo from '../assets/nais3-logo.svg'
 import { playChime } from '../lib/completion-alert'
@@ -642,14 +642,18 @@ function AccountSection(): React.JSX.Element {
               {opusUsage ? `${displayOpusUsagePercent(opusUsage)}%` : '—'}
             </span>
           </div>
-          <div className="h-2 overflow-hidden rounded-full bg-paper">
-            <div
-              className={cn(
-                'h-full max-w-full rounded-full transition-[width] duration-300',
-                opusUsage?.isNegative ? 'bg-danger' : 'bg-accent'
-              )}
-              style={{ width: `${opusUsage ? displayOpusUsagePercent(opusUsage) : 0}%` }}
-            />
+          <div className="flex h-2 gap-1">
+            {(opusUsage ? opusUsagePercentSegments(opusUsage) : [0]).map((percent, index) => (
+              <div key={index} className="h-full flex-1 overflow-hidden rounded-full bg-paper">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-[width] duration-300',
+                    opusUsage?.isNegative ? 'bg-danger' : 'bg-accent'
+                  )}
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+            ))}
           </div>
           <p className="mt-2 text-[10.5px] text-faint">
             {opusUsage

--- a/src/shared/anlas.ts
+++ b/src/shared/anlas.ts
@@ -1,7 +1,7 @@
 import type { DirectorMethod, OpusUsageStatus } from './types'
 
 export function displayOpusUsagePercent(usage: OpusUsageStatus): number {
-  return usage.isNegative ? 0 : Math.max(0, Math.min(100, usage.percent))
+  return usage.isNegative ? 0 : Math.max(0, usage.percent)
 }
 
 /**

--- a/src/shared/anlas.ts
+++ b/src/shared/anlas.ts
@@ -4,6 +4,15 @@ export function displayOpusUsagePercent(usage: OpusUsageStatus): number {
   return usage.isNegative ? 0 : Math.max(0, usage.percent)
 }
 
+export function opusUsagePercentSegments(usage: OpusUsageStatus): number[] {
+  const percent = displayOpusUsagePercent(usage)
+  const fullSegments = Math.floor(percent / 100)
+  const remainder = percent % 100
+
+  if (fullSegments === 0) return [remainder]
+  return [...Array.from({ length: fullSegments }, () => 100), ...(remainder > 0 ? [remainder] : [])]
+}
+
 /**
  * Anlas 비용 추정 — NAI 웹 번들의 실제 비용 함수를 이식 (2026-07-05 _app 번들에서 추출).
  *

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -114,7 +114,7 @@ export interface QueueStatus {
 }
 
 export interface OpusUsageStatus {
-  /** Remaining rechargeable allowance, 0-100. */
+  /** Remaining rechargeable allowance percentage. May exceed 100 during boosts. */
   percent: number
   /** True once the allowance is exhausted and V5 falls back to Anlas. */
   isNegative: boolean

--- a/tests/anlas.test.ts
+++ b/tests/anlas.test.ts
@@ -5,7 +5,8 @@ import {
   displayOpusUsagePercent,
   effectiveGenerationStrength,
   estimateAnlas,
-  formatAnlasEstimate
+  formatAnlasEstimate,
+  opusUsagePercentSegments
 } from '../src/shared/anlas'
 
 const base = {
@@ -32,6 +33,21 @@ describe('Anlas 추정 (NAI 웹 공식 이식)', () => {
     expect(
       displayOpusUsagePercent({ percent: 35, isNegative: true, timeUntilNextPercent: 0 })
     ).toBe(0)
+  })
+
+  it('V5 Usage 막대는 100% 단위 구간으로 나눈다', () => {
+    expect(
+      opusUsagePercentSegments({ percent: 70, isNegative: false, timeUntilNextPercent: 0 })
+    ).toEqual([70])
+    expect(
+      opusUsagePercentSegments({ percent: 130, isNegative: false, timeUntilNextPercent: 0 })
+    ).toEqual([100, 30])
+    expect(
+      opusUsagePercentSegments({ percent: 230, isNegative: false, timeUntilNextPercent: 0 })
+    ).toEqual([100, 100, 30])
+    expect(
+      opusUsagePercentSegments({ percent: 200, isNegative: false, timeUntilNextPercent: 0 })
+    ).toEqual([100, 100])
   })
 
   it('기본 해상도 28스텝 = 장당 20 Anlas (커뮤니티 공지값과 일치)', () => {

--- a/tests/anlas.test.ts
+++ b/tests/anlas.test.ts
@@ -19,13 +19,16 @@ const base = {
 }
 
 describe('Anlas 추정 (NAI 웹 공식 이식)', () => {
-  it('V5 Usage 퍼센트는 정상 범위로 고정하고 소진 상태는 0%로 표시한다', () => {
+  it('V5 Usage 퍼센트는 부스트 값을 유지하고 소진 상태만 0%로 표시한다', () => {
     expect(
       displayOpusUsagePercent({ percent: 100, isNegative: false, timeUntilNextPercent: 0 })
     ).toBe(100)
     expect(
       displayOpusUsagePercent({ percent: 120, isNegative: false, timeUntilNextPercent: 0 })
-    ).toBe(100)
+    ).toBe(120)
+    expect(
+      displayOpusUsagePercent({ percent: -30, isNegative: false, timeUntilNextPercent: 0 })
+    ).toBe(0)
     expect(
       displayOpusUsagePercent({ percent: 35, isNegative: true, timeUntilNextPercent: 0 })
     ).toBe(0)

--- a/tests/subscription.test.ts
+++ b/tests/subscription.test.ts
@@ -21,6 +21,11 @@ describe('V5 Opus usage 응답', () => {
     expect(parseSubscriptionResponse({ tier: 1 }).usage).toBeUndefined()
   })
 
+  it('부스트로 100%를 넘긴 usage도 상한 없이 전달한다', () => {
+    const usage = { percent: 230, isNegative: false, timeUntilNextPercent: 6048 }
+    expect(parseSubscriptionResponse({ tier: 3, usage }).usage).toEqual(usage)
+  })
+
   it('잘못된 usage 값은 UI에 전달하지 않는다', () => {
     expect(
       parseSubscriptionResponse({


### PR DESCRIPTION
## Summary

- accept finite V5 Opus quota percentages without imposing a 100% ceiling
- preserve boosted values in the UI while keeping exhausted or negative display values at 0%
- split the quota bar into 100% segments (for example, 230% renders as 100% + 100% + 30%)
- add coverage for boosted subscription responses and segmented quota display

## Testing

- `npm test` (113 tests passed)
- `npm run typecheck`
- `git diff --check`

Closes #3