### PR TITLE
feat: match NovelAI resolution presets and custom limits

### DIFF
--- a/src/renderer/src/components/resolution-picker.tsx
+++ b/src/renderer/src/components/resolution-picker.tsx
@@ -1,14 +1,16 @@
 import { useState } from 'react'
 import { Check, ChevronDown, Plus, Trash2 } from 'lucide-react'
+import { fitNaiGenerationResolution, type ResolutionDimension } from '@shared/nai-resolution'
 import { RESOLUTIONS } from '../lib/constants'
-import { useResolutionsStore, snapDim } from '../stores/resolutions-store'
+import { useResolutionsStore } from '../stores/resolutions-store'
 import { toast } from '../stores/toast-store'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { cn } from '../lib/utils'
 
 /**
  * 해상도 선택 — 기본 해상도(삭제 불가) + 커스텀 해상도(추가/삭제).
- * 커스텀은 64 배수로 스냅(생성 실패 방지). 가격/레이아웃은 width·height 기준이라 자동 대응.
+ * 커스텀은 NovelAI 웹과 같이 64 배수·총 3 Mi 픽셀 제한으로 보정한다.
+ * 가격/레이아웃은 width·height 기준이라 자동 대응.
  */
 export function ResolutionPicker({
   width,
@@ -29,6 +31,10 @@ export function ResolutionPicker({
   const [open, setOpen] = useState(false)
   const [w, setW] = useState('')
   const [h, setH] = useState('')
+  const [lastEditedDimension, setLastEditedDimension] = useState<ResolutionDimension>('height')
+
+  const customPreview =
+    w && h ? fitNaiGenerationResolution(Number(w), Number(h), lastEditedDimension) : null
 
   const currentLabel =
     RESOLUTIONS.find((r) => r.width === width && r.height === height)?.label ??
@@ -41,13 +47,13 @@ export function ResolutionPicker({
     const nw = Number(w)
     const nh = Number(h)
     if (!nw || !nh) return
-    const item = add(nw, nh)
+    const item = add(nw, nh, lastEditedDimension)
     if (item) {
       onPick(item.width, item.height)
       setW('')
       setH('')
       if (item.width !== nw || item.height !== nh)
-        toast(`64 배수로 스냅됨 → ${item.width}×${item.height}`, 'info')
+        toast(`64 배수·3 Mi 픽셀 제한으로 보정됨 → ${item.width}×${item.height}`, 'info')
     } else {
       toast('이미 있는 해상도입니다', 'info')
     }
@@ -113,11 +119,14 @@ export function ResolutionPicker({
           ))}
         </div>
 
-        {/* 커스텀 추가 — 64 배수로 스냅됨 */}
+        {/* 커스텀 추가 — 64 배수·총 3 Mi 픽셀 제한으로 보정됨 */}
         <div className="mt-1 flex items-center gap-1 border-t border-line pt-1.5">
           <input
             value={w}
-            onChange={(e) => setW(e.target.value.replace(/[^0-9]/g, ''))}
+            onChange={(e) => {
+              setW(e.target.value.replace(/[^0-9]/g, ''))
+              setLastEditedDimension('width')
+            }}
             placeholder="가로"
             inputMode="numeric"
             className="h-7 w-0 flex-1 rounded border border-line bg-paper px-1.5 text-center text-[12px] outline-none focus:border-accent/50"
@@ -125,14 +134,21 @@ export function ResolutionPicker({
           <span className="text-[11px] text-faint">×</span>
           <input
             value={h}
-            onChange={(e) => setH(e.target.value.replace(/[^0-9]/g, ''))}
+            onChange={(e) => {
+              setH(e.target.value.replace(/[^0-9]/g, ''))
+              setLastEditedDimension('height')
+            }}
             placeholder="세로"
             inputMode="numeric"
             onKeyDown={(e) => e.key === 'Enter' && doAdd()}
             className="h-7 w-0 flex-1 rounded border border-line bg-paper px-1.5 text-center text-[12px] outline-none focus:border-accent/50"
           />
           <button
-            title={w && h ? `추가 (64 배수 스냅: ${snapDim(Number(w))}×${snapDim(Number(h))})` : '추가'}
+            title={
+              customPreview
+                ? `추가 (NovelAI 보정: ${customPreview.width}×${customPreview.height})`
+                : '추가'
+            }
             onClick={doAdd}
             className="grid size-7 shrink-0 place-items-center rounded bg-accent text-paper hover:opacity-90"
           >

--- a/src/renderer/src/lib/constants.ts
+++ b/src/renderer/src/lib/constants.ts
@@ -22,7 +22,13 @@ export const RESOLUTIONS = [
   { label: '가로 (1216×832)', width: 1216, height: 832 },
   { label: '정사각 (1024×1024)', width: 1024, height: 1024 },
   { label: '세로 대형 (1024×1536)', width: 1024, height: 1536 },
-  { label: '가로 대형 (1536×1024)', width: 1536, height: 1024 }
+  { label: '가로 대형 (1536×1024)', width: 1536, height: 1024 },
+  { label: '정사각 대형 (1472×1472)', width: 1472, height: 1472 },
+  { label: '세로 배경화면 (1088×1920)', width: 1088, height: 1920 },
+  { label: '가로 배경화면 (1920×1088)', width: 1920, height: 1088 },
+  { label: '세로 소형 (512×768)', width: 512, height: 768 },
+  { label: '가로 소형 (768×512)', width: 768, height: 512 },
+  { label: '정사각 소형 (640×640)', width: 640, height: 640 }
 ] as const
 
 /** 실캡처 확정 매핑 — 2는 미사용이라 UI에 노출하지 않는다 */

--- a/src/renderer/src/stores/resolutions-store.ts
+++ b/src/renderer/src/stores/resolutions-store.ts
@@ -1,4 +1,9 @@
 import { create } from 'zustand'
+import {
+  fitNaiGenerationResolution,
+  snapNaiDimension,
+  type ResolutionDimension
+} from '@shared/nai-resolution'
 
 export interface CustomResolution {
   label: string
@@ -8,7 +13,11 @@ export interface CustomResolution {
 
 interface ResolutionsState {
   custom: CustomResolution[]
-  add: (width: number, height: number) => CustomResolution | null
+  add: (
+    width: number,
+    height: number,
+    preservedDimension?: ResolutionDimension
+  ) => CustomResolution | null
   remove: (index: number) => void
 }
 
@@ -26,17 +35,14 @@ function save(list: CustomResolution[]): void {
   localStorage.setItem(KEY, JSON.stringify(list))
 }
 
-/** NAI 유효 해상도로 스냅 — 64의 배수, 각 변 [64, 2048]. 생성 실패 방지 */
-export function snapDim(n: number): number {
-  return Math.max(64, Math.min(2048, Math.round(n / 64) * 64))
-}
+export const snapDim = snapNaiDimension
 
 export const useResolutionsStore = create<ResolutionsState>((set, get) => ({
   custom: load(),
-  add: (width, height) => {
-    const w = snapDim(width)
-    const h = snapDim(height)
-    if (!Number.isFinite(w) || !Number.isFinite(h)) return null
+  add: (width, height, preservedDimension = 'height') => {
+    const fitted = fitNaiGenerationResolution(width, height, preservedDimension)
+    if (!fitted) return null
+    const { width: w, height: h } = fitted
     // 이미 있으면(기본/커스텀 무관) 추가 안 함 — 중복 방지는 UI에서, 여기선 커스텀 중복만 체크
     if (get().custom.some((r) => r.width === w && r.height === h)) return null
     const item = { label: `${w}×${h}`, width: w, height: h }

--- a/src/shared/nai-resolution.ts
+++ b/src/shared/nai-resolution.ts
@@ -1,3 +1,46 @@
+export const NAI_RESOLUTION_STEP = 64
+export const NAI_MIN_RESOLUTION = 64
+export const NAI_MAX_GENERATION_PIXELS = 3 * 1024 * 1024
+
+export type ResolutionDimension = 'width' | 'height'
+
+export function snapNaiDimension(value: number): number {
+  if (!Number.isFinite(value)) return Number.NaN
+  return Math.max(NAI_MIN_RESOLUTION, Math.round(value / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP)
+}
+
+/**
+ * NovelAI 웹의 Custom 해상도 규칙: 64 배수로 맞추고 총 3 Mi 픽셀을 넘으면
+ * 마지막으로 편집한 변은 유지하면서 반대 변을 64 단위로 줄인다.
+ */
+export function fitNaiGenerationResolution(
+  inputWidth: number,
+  inputHeight: number,
+  preservedDimension: ResolutionDimension = 'height'
+): { width: number; height: number } | null {
+  let width = snapNaiDimension(inputWidth)
+  let height = snapNaiDimension(inputHeight)
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null
+  if (width * height <= NAI_MAX_GENERATION_PIXELS) return { width, height }
+
+  const maxPreservedDimension = NAI_MAX_GENERATION_PIXELS / NAI_MIN_RESOLUTION
+  if (preservedDimension === 'width') {
+    width = Math.min(width, maxPreservedDimension)
+    height = Math.max(
+      NAI_MIN_RESOLUTION,
+      Math.floor(NAI_MAX_GENERATION_PIXELS / width / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP
+    )
+  } else {
+    height = Math.min(height, maxPreservedDimension)
+    width = Math.max(
+      NAI_MIN_RESOLUTION,
+      Math.floor(NAI_MAX_GENERATION_PIXELS / height / NAI_RESOLUTION_STEP) * NAI_RESOLUTION_STEP
+    )
+  }
+
+  return { width, height }
+}
+
 /** 소스 해상도를 유효 NAI 해상도로 스냅 — 64 배수, 픽셀 상한 내에서 비율 최대한 보존 */
 export function snapNaiResolution(w: number, h: number): { width: number; height: number } {
   const maxPixels = 1216 * 1216
@@ -8,6 +51,6 @@ export function snapNaiResolution(w: number, h: number): { width: number; height
     width *= scale
     height *= scale
   }
-  const snap = (value: number): number => Math.max(64, Math.round(value / 64) * 64)
+  const snap = (value: number): number => snapNaiDimension(value)
   return { width: snap(width), height: snap(height) }
 }

--- a/tests/nai-resolution.test.ts
+++ b/tests/nai-resolution.test.ts
@@ -1,8 +1,47 @@
 import { describe, expect, it } from 'vitest'
-import { snapNaiResolution } from '../src/shared/nai-resolution'
+import {
+  NAI_MAX_GENERATION_PIXELS,
+  fitNaiGenerationResolution,
+  snapNaiDimension,
+  snapNaiResolution
+} from '../src/shared/nai-resolution'
 
 describe('NAI 소스 해상도 스냅', () => {
   it('64 배수로 맞추고 서버 전송 크기와 비용 표시가 공유할 값을 반환한다', () => {
     expect(snapNaiResolution(300, 412)).toEqual({ width: 320, height: 384 })
+  })
+})
+
+describe('NAI Custom 생성 해상도 보정', () => {
+  it('공식 웹처럼 각 변을 64 배수로 맞춘다', () => {
+    expect(snapNaiDimension(1440)).toBe(1472)
+    expect(fitNaiGenerationResolution(1000, 1000)).toEqual({ width: 1024, height: 1024 })
+  })
+
+  it('정확히 3 Mi 픽셀인 해상도는 그대로 허용한다', () => {
+    const resolution = fitNaiGenerationResolution(2048, 1536)
+    expect(resolution).toEqual({ width: 2048, height: 1536 })
+    expect(resolution!.width * resolution!.height).toBe(NAI_MAX_GENERATION_PIXELS)
+  })
+
+  it('높이를 마지막으로 편집한 QHD 입력은 높이를 유지하고 폭을 줄인다', () => {
+    expect(fitNaiGenerationResolution(2560, 1440, 'height')).toEqual({
+      width: 2112,
+      height: 1472
+    })
+  })
+
+  it('폭을 마지막으로 편집한 QHD 입력은 폭을 유지하고 높이를 줄인다', () => {
+    expect(fitNaiGenerationResolution(2560, 1440, 'width')).toEqual({
+      width: 2560,
+      height: 1216
+    })
+  })
+
+  it('한 변이 2048을 넘어도 총 픽셀 상한 이하면 유지한다', () => {
+    expect(fitNaiGenerationResolution(3200, 768, 'width')).toEqual({
+      width: 3200,
+      height: 768
+    })
   })
 })


### PR DESCRIPTION
## Summary

- add the current NovelAI V5 Large square, Wallpaper, and Small resolution presets
- match the NovelAI Custom resolution behavior with 64-pixel steps and a 3 Mi-pixel cap
- preserve the last-edited dimension when reducing an oversized custom resolution
- remove the artificial 2048-pixel per-dimension cap and preview corrected dimensions in the picker

## Web contract verification

- confirmed 2048x1536 is accepted unchanged at exactly 3 Mi pixels
- confirmed 2112x1536 is corrected to 2048x1536
- confirmed 2560x1440 is corrected to 2112x1472 or 2560x1216 depending on the last-edited dimension

## Validation

- npm run typecheck
- focused ESLint on the changed files
- npm test (12 test files, 124 tests)