### PR TITLE
fix: match V5 Auto Text prompt handling

### DIFF
--- a/src/main/nai/payload.ts
+++ b/src/main/nai/payload.ts
@@ -37,6 +37,7 @@ import {
   removeComments
 } from '../../shared/nai-presets'
 import { isV5Model, modelCapabilities } from '../../shared/nai-models'
+import { applyAutoText } from '../../shared/nai-auto-text'
 
 /**
  * Variety+(skip_cfg_above_sigma) 값.
@@ -141,7 +142,7 @@ export function buildGenerateImagePayload(
   const transparent = v5 && (opts.transparentBackground ?? req.transparentBackground ?? false)
   const userPrompt = removeComments(req.prompt)
   const qualityPrompt = mergeQualityTags(userPrompt, req.qualityToggle)
-  const prompt = transparent
+  const promptWithQuality = transparent
     ? mergeQualityTags(
         userPrompt ? `${userPrompt}, transparent background` : 'transparent background',
         req.qualityToggle
@@ -160,6 +161,11 @@ export function buildGenerateImagePayload(
     }))
     .filter((c) => c.enabled && c.prompt.trim())
     .slice(0, capabilities.maxCharacters)
+  // V5 웹의 Auto Text: 따옴표 속 문구를 마지막 `teXt:` 블록으로 반복해 문자 렌더링에 전달한다.
+  // 품질 태그의 `no text` 뒤에 와야 하며, input과 v4_prompt.base_caption은 같은 값을 써야 한다.
+  const prompt = v5
+    ? applyAutoText(promptWithQuality, activeChars, req.useCoords)
+    : promptWithQuality
   const center = (c: (typeof activeChars)[number]): { x: number; y: number } =>
     req.useCoords ? (c.center ?? { x: 0.5, y: 0.5 }) : { x: 0.5, y: 0.5 }
 
@@ -202,7 +208,9 @@ export function buildGenerateImagePayload(
       qualityToggle: req.qualityToggle,
       ...(v5
         ? {
-            tag_hint_qt: req.qualityToggle ? QUALITY_PRESET_HINT.standard : QUALITY_PRESET_HINT.none,
+            tag_hint_qt: req.qualityToggle
+              ? QUALITY_PRESET_HINT.standard
+              : QUALITY_PRESET_HINT.none,
             tag_hint_uc_preset: UC_PRESET_HINT[req.ucPreset],
             ...(transparent
               ? {

--- a/src/shared/nai-auto-text.ts
+++ b/src/shared/nai-auto-text.ts
@@ -1,0 +1,161 @@
+const MAX_PROMPT_SECTIONS = 6
+const SECTION_SEPARATOR = '|'
+const ESCAPED_SECTION_SEPARATOR = '||'
+const ESCAPED_SINGLE_SENTINEL = '\u{103B9}'
+const ESCAPED_DOUBLE_SENTINEL = '\u{12137}'
+
+const TEXT_MARKER = /(?:^|\s|[,.:[\]{}\n、。])text:(?!:)/i
+const AUTO_TEXT_MARKER = 'teXt:'
+
+const QUOTE_PAIRS: Record<string, string> = {
+  '"': '"',
+  '“': '”',
+  '「': '」',
+  "'": "'",
+  '‘': '’'
+}
+
+const JAPANESE_CHARACTERS =
+  /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]/gu
+
+export interface AutoTextCharacterPrompt {
+  prompt: string
+  enabled?: boolean
+  center?: { x: number; y: number }
+}
+
+/** NovelAI 웹과 동일하게 `|` 프롬프트 구역을 나누되 `||...||` 안의 `|`는 보존한다. */
+function splitPromptSections(prompt: string): string[] {
+  const protectedPrompt = prompt
+    .split(ESCAPED_SECTION_SEPARATOR)
+    .map((part, index) =>
+      index % 2 === 1 ? part.split(SECTION_SEPARATOR).join(ESCAPED_SINGLE_SENTINEL) : part
+    )
+    .join(ESCAPED_DOUBLE_SENTINEL)
+  const sections = protectedPrompt.split(SECTION_SEPARATOR)
+  const limited = sections.slice(0, MAX_PROMPT_SECTIONS - 1)
+  if (sections.length > MAX_PROMPT_SECTIONS - 1) {
+    limited.push(sections.slice(MAX_PROMPT_SECTIONS - 1).join(SECTION_SEPARATOR))
+  }
+  return limited.map((section) =>
+    section
+      .replaceAll(ESCAPED_SINGLE_SENTINEL, SECTION_SEPARATOR)
+      .replaceAll(ESCAPED_DOUBLE_SENTINEL, ESCAPED_SECTION_SEPARATOR)
+  )
+}
+
+function isLetterOrNumber(char: string | undefined): boolean {
+  return char !== undefined && /[\p{L}\p{N}]/u.test(char)
+}
+
+function isQuoteBoundary(char: string | undefined): boolean {
+  return char === undefined || /[\s,.]/.test(char)
+}
+
+function extractQuotedText(prompt: string): string[] {
+  const found: string[] = []
+  let cursor = 0
+  while (cursor < prompt.length) {
+    const opening = prompt[cursor]
+    const closing = QUOTE_PAIRS[opening]
+    if (closing === undefined || (opening === "'" && !isQuoteBoundary(prompt[cursor - 1]))) {
+      cursor++
+      continue
+    }
+
+    const apostropheLike = closing === "'" || closing === '’'
+    let end = cursor + 1
+    while (
+      end < prompt.length &&
+      (prompt[end] !== closing || (apostropheLike && isLetterOrNumber(prompt[end + 1])))
+    ) {
+      end++
+    }
+    if (end >= prompt.length) {
+      cursor++
+      continue
+    }
+
+    const text = prompt.slice(cursor + 1, end).trim()
+    if (text) found.push(text)
+    cursor = end + 1
+  }
+  return found
+}
+
+function splitRows<T extends { center: { x: number; y: number } }>(items: T[]): T[][] {
+  if (items.length <= 1) return [items]
+  const totalY = items[items.length - 1].center.y - items[0].center.y
+  let splitAt = 1
+  let largestGap = -1
+  for (let index = 1; index < items.length; index++) {
+    const gap = items[index].center.y - items[index - 1].center.y
+    if (gap > largestGap) {
+      largestGap = gap
+      splitAt = index
+    }
+  }
+  if (totalY <= 0.15 && largestGap <= 0.1) return [items]
+  return [...splitRows(items.slice(0, splitAt)), ...splitRows(items.slice(splitAt))]
+}
+
+function charactersInReadingOrder(
+  characters: (AutoTextCharacterPrompt & { center: { x: number; y: number } })[]
+): AutoTextCharacterPrompt[] {
+  return splitRows([...characters].sort((a, b) => a.center.y - b.center.y)).flatMap((row) =>
+    row.sort((a, b) => a.center.x - b.center.x)
+  )
+}
+
+function isMostlyJapanese(text: string): boolean {
+  const count = text.match(JAPANESE_CHARACTERS)?.length ?? 0
+  return count > 0 && count / text.length > 0.3
+}
+
+function autoTextEntries(
+  basePrompt: string,
+  characters: AutoTextCharacterPrompt[],
+  useCoords: boolean
+): string[] {
+  const enabled = characters.filter((character) => character.enabled !== false && character.prompt)
+  const ordered = useCoords
+    ? charactersInReadingOrder(
+        enabled.map((character) => ({
+          ...character,
+          center: character.center ?? { x: 0.5, y: 0.5 }
+        }))
+      )
+    : enabled
+  const groups = [
+    extractQuotedText(basePrompt),
+    ...ordered.map((item) => extractQuotedText(item.prompt))
+  ]
+  if (isMostlyJapanese(groups.flat().join(''))) {
+    for (const group of groups) group.reverse()
+  }
+  return groups.flat()
+}
+
+/**
+ * V5 웹의 Auto Text 동작: 따옴표 속 문구를 찾아 첫 프롬프트 구역 끝에 `teXt:`로 반복한다.
+ * 명시적인 `Text:`가 이미 있으면 사용자의 순서와 내용을 그대로 존중한다.
+ */
+export function applyAutoText(
+  prompt: string,
+  characters: AutoTextCharacterPrompt[] = [],
+  useCoords = false
+): string {
+  const enabled = characters.filter((character) => character.enabled !== false && character.prompt)
+  if (TEXT_MARKER.test(prompt) || enabled.some((character) => TEXT_MARKER.test(character.prompt))) {
+    return prompt
+  }
+
+  const sections = splitPromptSections(prompt)
+  const entries = autoTextEntries(sections[0] ?? '', enabled, useCoords)
+  if (entries.length === 0) return prompt
+
+  const textBlock = `${AUTO_TEXT_MARKER} ${entries.join('\n\n')}`
+  const base = (sections[0] ?? '').replace(/[\s,]+$/, '')
+  sections[0] = base ? `${base}, ${textBlock}` : textBlock
+  return sections.join(SECTION_SEPARATOR)
+}

--- a/tests/nai-auto-text.test.ts
+++ b/tests/nai-auto-text.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { applyAutoText } from '../src/shared/nai-auto-text'
+
+describe('NovelAI V5 Auto Text', () => {
+  it('한글 인용문을 teXt 블록으로 반복한다', () => {
+    expect(applyAutoText('"텍스트"')).toBe('"텍스트", teXt: 텍스트')
+    expect(applyAutoText('간판에 "안녕하세요"라고 쓰여 있음')).toBe(
+      '간판에 "안녕하세요"라고 쓰여 있음, teXt: 안녕하세요'
+    )
+  })
+
+  it('스마트 따옴표와 여러 문구를 빈 줄로 구분한다', () => {
+    expect(applyAutoText("“첫째”, 「둘째」, 'third'")).toBe(
+      "“첫째”, 「둘째」, 'third', teXt: 첫째\n\n둘째\n\nthird"
+    )
+  })
+
+  it('단어 안의 apostrophe는 인용문으로 취급하지 않는다', () => {
+    expect(applyAutoText("don't render this")).toBe("don't render this")
+  })
+
+  it('명시적인 Text 블록이 있으면 자동 변환하지 않는다', () => {
+    expect(applyAutoText('sign, Text: 직접 지정')).toBe('sign, Text: 직접 지정')
+    expect(applyAutoText('sign', [{ prompt: 'Text: 캐릭터 지정' }])).toBe('sign')
+  })
+
+  it('캐릭터 프롬프트의 인용문도 메인 Text 블록에 포함한다', () => {
+    expect(
+      applyAutoText('two people', [
+        { prompt: 'saying "왼쪽"', center: { x: 0.1, y: 0.5 } },
+        { prompt: 'saying "오른쪽"', center: { x: 0.9, y: 0.5 } }
+      ])
+    ).toBe('two people, teXt: 왼쪽\n\n오른쪽')
+  })
+
+  it('좌표를 사용할 때 캐릭터 문구를 화면 읽기 순서로 정렬한다', () => {
+    expect(
+      applyAutoText(
+        'comic',
+        [
+          { prompt: '"오른쪽"', center: { x: 0.9, y: 0.1 } },
+          { prompt: '"아래"', center: { x: 0.5, y: 0.8 } },
+          { prompt: '"왼쪽"', center: { x: 0.1, y: 0.1 } }
+        ],
+        true
+      )
+    ).toBe('comic, teXt: 왼쪽\n\n오른쪽\n\n아래')
+  })
+
+  it('첫 프롬프트 구역에만 Text 블록을 넣고 나머지 구역은 보존한다', () => {
+    expect(applyAutoText('base "문구"|character|background')).toBe(
+      'base "문구", teXt: 문구|character|background'
+    )
+  })
+})

--- a/tests/payload.test.ts
+++ b/tests/payload.test.ts
@@ -61,6 +61,44 @@ describe('payload builder', () => {
     expect(p.parameters.negative_prompt).not.toMatch(/^nsfw, /)
   })
 
+  it('V5는 인용된 한글을 품질 태그 뒤의 Auto Text 블록으로 전달한다', () => {
+    const p = buildGenerateImagePayload({
+      ...baseRequest,
+      prompt: '간판에 "텍스트"',
+      model: 'nai-diffusion-5-curated',
+      qualityToggle: true
+    })
+    const expected = '간판에 "텍스트", very aesthetic, masterpiece, no text, teXt: 텍스트'
+    expect(p.input).toBe(expected)
+    expect(
+      (p.parameters.v4_prompt as { caption: { base_caption: string } }).caption.base_caption
+    ).toBe(expected)
+  })
+
+  it('V5 Auto Text는 활성 캐릭터 프롬프트의 인용문도 포함한다', () => {
+    const p = buildGenerateImagePayload({
+      ...baseRequest,
+      prompt: 'two people',
+      model: 'nai-diffusion-5-full',
+      qualityToggle: false,
+      characterPrompts: [
+        { prompt: 'saying "왼쪽"', negativePrompt: '', enabled: true },
+        { prompt: 'saying "제외"', negativePrompt: '', enabled: false },
+        { prompt: 'saying "오른쪽"', negativePrompt: '', enabled: true }
+      ]
+    })
+    expect(p.input).toBe('two people, teXt: 왼쪽\n\n오른쪽')
+  })
+
+  it('V4.5 프롬프트에는 V5 Auto Text 변환을 적용하지 않는다', () => {
+    const p = buildGenerateImagePayload({
+      ...baseRequest,
+      prompt: '간판에 "텍스트"',
+      qualityToggle: false
+    })
+    expect(p.input).toBe('간판에 "텍스트"')
+  })
+
   it('V5 투명 배경은 태그·straight alpha·서버 힌트를 함께 보낸다', () => {
     const p = buildGenerateImagePayload(
       { ...baseRequest, model: 'nai-diffusion-5-curated', qualityToggle: true },


### PR DESCRIPTION
## Summary

- mirror NovelAI web's V5 Auto Text preprocessing for quoted text
- collect quoted strings from the base prompt and enabled character prompts, then append the final `teXt:` block after quality tags
- preserve explicit `Text:` blocks and leave non-V5 prompt behavior unchanged
- add focused Korean, quote-style, character-ordering, and payload regression coverage

## Why

NAIS3 sent quoted text such as `"text"` without the Auto Text block that NovelAI web adds before generation. With the default quality suffix also containing `no text`, short Korean text could render as malformed glyphs even when the visible prompt and seed matched the web UI.

## Testing

- `npm test` (129 tests)
- `npm run typecheck`
- changed-file ESLint and Prettier checks
- `git diff --check`

Closes #13
