### PR TITLE
feat: add default Fragments prompts

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3'
+import { seedDefaultDanbooruFragments } from '../fragments/defaults'
 
 /**
  * 버전드 마이그레이션. 배열 인덱스+1 = 적용 후 user_version.
@@ -337,5 +338,10 @@ export const migrations: ((db: Database.Database) => void)[] = [
          WHERE folder_id IS NOT NULL AND folder_id NOT IN (SELECT id FROM ${folders});`
       )
     }
+  },
+
+  // v18: lightweight Danbooru-based defaults. Existing fragments win on name collisions.
+  (db) => {
+    seedDefaultDanbooruFragments(db)
   }
 ]

--- a/src/main/fragments/defaults.ts
+++ b/src/main/fragments/defaults.ts
@@ -1,0 +1,192 @@
+import type Database from 'better-sqlite3'
+
+export interface DefaultFragment {
+  name: string
+  content: string
+}
+
+export const DEFAULT_DANBOORU_FOLDER = 'Default'
+
+/**
+ * Small, general-purpose wildcard set curated from resources/tags.json.
+ * Lines are ordered by Danbooru post count so common choices remain easy to inspect.
+ */
+export const DEFAULT_DANBOORU_FRAGMENTS: readonly DefaultFragment[] = [
+  {
+    name: 'Hair color',
+    content: [
+      'black hair',
+      'blonde hair',
+      'brown hair',
+      'blue hair',
+      'pink hair',
+      'white hair',
+      'grey hair',
+      'purple hair',
+      'red hair',
+      'green hair',
+      'orange hair',
+      'aqua hair'
+    ].join('\n')
+  },
+  {
+    name: 'Eye color',
+    content: [
+      'blue eyes',
+      'red eyes',
+      'purple eyes',
+      'green eyes',
+      'brown eyes',
+      'yellow eyes',
+      'pink eyes',
+      'black eyes',
+      'grey eyes',
+      'aqua eyes',
+      'orange eyes'
+    ].join('\n')
+  },
+  {
+    name: 'Hairstyle',
+    content: [
+      'long hair',
+      'short hair',
+      'very long hair',
+      'twintails',
+      'ponytail',
+      'braid',
+      'hair bun',
+      'twin braids',
+      'side ponytail',
+      'bob cut'
+    ].join('\n')
+  },
+  {
+    name: 'Expression',
+    content: [
+      'smile',
+      'blush',
+      'open mouth',
+      'closed mouth',
+      'closed eyes',
+      'one eye closed',
+      'tongue out',
+      'grin',
+      'tears',
+      'surprised'
+    ].join('\n')
+  },
+  {
+    name: 'Composition',
+    content: [
+      'looking at viewer',
+      'full body',
+      'upper body',
+      'cowboy shot',
+      'looking back',
+      'from side',
+      'from behind',
+      'portrait',
+      'close-up'
+    ].join('\n')
+  },
+  {
+    name: 'Pose',
+    content: [
+      'standing',
+      'sitting',
+      'lying',
+      'hands up',
+      'arms up',
+      'hand on own hip',
+      'kneeling',
+      'squatting'
+    ].join('\n')
+  },
+  {
+    name: 'Setting',
+    content: [
+      'simple background',
+      'white background',
+      'outdoors',
+      'sky',
+      'indoors',
+      'beach',
+      'forest',
+      'city',
+      'classroom',
+      'bedroom'
+    ].join('\n')
+  },
+  {
+    name: 'Outfit',
+    content: [
+      'shirt',
+      'skirt',
+      'dress',
+      'school uniform',
+      'swimsuit',
+      'kimono',
+      'armor',
+      'maid',
+      'hoodie',
+      'suit'
+    ].join('\n')
+  }
+]
+
+export interface DefaultDanbooruSeedPlan {
+  folderName: string
+  fragments: readonly DefaultFragment[]
+}
+
+function uniqueFolderName(existingNames: ReadonlySet<string>, base: string): string {
+  if (!existingNames.has(base)) return base
+  for (let i = 2; ; i++) {
+    const candidate = `${base} (${i})`
+    if (!existingNames.has(candidate)) return candidate
+  }
+}
+
+export function planDefaultDanbooruSeed(
+  existingFragmentNames: Iterable<string>,
+  existingFolderNames: Iterable<string>
+): DefaultDanbooruSeedPlan | null {
+  const fragmentNames = new Set(existingFragmentNames)
+  const missing = DEFAULT_DANBOORU_FRAGMENTS.filter((fragment) => !fragmentNames.has(fragment.name))
+  if (missing.length === 0) return null
+
+  return {
+    folderName: uniqueFolderName(new Set(existingFolderNames), DEFAULT_DANBOORU_FOLDER),
+    fragments: missing
+  }
+}
+
+/** Add missing defaults without changing any user-created fragment or folder. */
+export function seedDefaultDanbooruFragments(db: Database.Database): void {
+  const fragmentNames = db.prepare('SELECT name FROM fragments').all() as { name: string }[]
+  const folderNames = db.prepare('SELECT name FROM fragment_folders').all() as { name: string }[]
+  const plan = planDefaultDanbooruSeed(
+    fragmentNames.map((row) => row.name),
+    folderNames.map((row) => row.name)
+  )
+  if (!plan) return
+
+  const folderOrder = db
+    .prepare('SELECT COALESCE(MAX(sort_order), 0) AS value FROM fragment_folders')
+    .get() as { value: number }
+  const folderId = Number(
+    db
+      .prepare('INSERT INTO fragment_folders (name, sort_order) VALUES (?, ?)')
+      .run(plan.folderName, folderOrder.value + 1).lastInsertRowid
+  )
+
+  const fragmentOrder = db
+    .prepare('SELECT COALESCE(MAX(sort_order), 0) AS value FROM fragments')
+    .get() as { value: number }
+  const insert = db.prepare(
+    'INSERT INTO fragments (name, content, folder_id, sort_order) VALUES (?, ?, ?, ?)'
+  )
+  plan.fragments.forEach((fragment, index) => {
+    insert.run(fragment.name, fragment.content, folderId, fragmentOrder.value + index + 1)
+  })
+}

--- a/tests/default-fragments.test.ts
+++ b/tests/default-fragments.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_DANBOORU_FOLDER,
+  DEFAULT_DANBOORU_FRAGMENTS,
+  planDefaultDanbooruSeed
+} from '../src/main/fragments/defaults'
+
+interface TagEntry {
+  value: string
+  count: number
+  type: string
+}
+
+const tags = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'resources', 'tags.json'), 'utf-8')
+) as TagEntry[]
+const tagsByName = new Map(tags.map((tag) => [tag.value, tag]))
+
+describe('기본 Danbooru 조각', () => {
+  it('작은 범용 세트만 제공한다', () => {
+    const lines = DEFAULT_DANBOORU_FRAGMENTS.flatMap((fragment) => fragment.content.split('\n'))
+
+    expect(DEFAULT_DANBOORU_FRAGMENTS).toHaveLength(8)
+    expect(lines.length).toBeLessThanOrEqual(80)
+    expect(new Set(DEFAULT_DANBOORU_FRAGMENTS.map((fragment) => fragment.name)).size).toBe(
+      DEFAULT_DANBOORU_FRAGMENTS.length
+    )
+    expect(new Set(lines).size).toBe(lines.length)
+  })
+
+  it('모든 줄이 autocomplete 데이터의 general 태그이며 인기순이다', () => {
+    for (const fragment of DEFAULT_DANBOORU_FRAGMENTS) {
+      const entries = fragment.content.split('\n').map((line) => tagsByName.get(line))
+      expect(entries.every((entry) => entry?.type === 'general')).toBe(true)
+
+      const counts = entries.map((entry) => entry?.count ?? -1)
+      expect(counts).toEqual([...counts].sort((a, b) => b - a))
+    }
+  })
+
+  it('설치할 기본 폴더와 조각을 계획한다', () => {
+    expect(planDefaultDanbooruSeed([], [])).toEqual({
+      folderName: DEFAULT_DANBOORU_FOLDER,
+      fragments: DEFAULT_DANBOORU_FRAGMENTS
+    })
+
+    expect(
+      planDefaultDanbooruSeed(
+        DEFAULT_DANBOORU_FRAGMENTS.map((fragment) => fragment.name),
+        [DEFAULT_DANBOORU_FOLDER]
+      )
+    ).toBeNull()
+  })
+
+  it('동일 이름의 사용자 조각과 폴더를 덮어쓰지 않는다', () => {
+    const plan = planDefaultDanbooruSeed(
+      ['Hair color'],
+      [DEFAULT_DANBOORU_FOLDER, `${DEFAULT_DANBOORU_FOLDER} (2)`]
+    )
+
+    expect(plan?.folderName).toBe(`${DEFAULT_DANBOORU_FOLDER} (3)`)
+    expect(plan?.fragments.map((fragment) => fragment.name)).not.toContain('Hair color')
+    expect(plan?.fragments).toHaveLength(DEFAULT_DANBOORU_FRAGMENTS.length - 1)
+  })
+})


### PR DESCRIPTION
## Summary

- seed an editable `Default` fragment folder with eight lightweight wildcard groups
- curate 80 popular general-purpose tags from the bundled `resources/tags.json` autocomplete data
- add the defaults through a v18 migration while preserving user fragments and separating folder-name collisions
- validate the curated tags, ordering, size bound, idempotence plan, and collision behavior

## Validation

- `npm test` (15 files, 141 tests)
- `npm run typecheck`
- focused ESLint and Prettier checks
- release-free Branch Build: Windows x64, macOS ARM64, and macOS Intel x64 all passed

| Preview |
|-----|
| <img width="467" height="894" alt="kwarkwenrwerwer" src="https://github.com/user-attachments/assets/f658d0db-de8c-43cd-95cf-0495beaaeaee" /> |

Build run: https://github.com/SameDesu123/NAIS3/actions/runs/33463373248