### PR TITLE
fix: preserve scene reservations during queue handoff

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -65,6 +65,7 @@ import { fetchAnlasBalance } from './nai/client'
 import { listImages, getImagePayload, saveGeneratedImage } from './images/storage'
 import { augmentImage, upscaleImage } from './nai/client'
 import {
+  enqueueReservedScenes,
   listPresets,
   createPreset,
   renamePreset,
@@ -253,6 +254,9 @@ export function registerIpcHandlers(ctx: { dbVersion: number; queue: GenerationQ
   })
   handle('nai:anlasUsage', () => anlasUsage())
 
+  handle('scenes:enqueueReserved', (request) => ({
+    ids: enqueueReservedScenes(ctx.queue, request)
+  }))
   handle('queue:enqueue', ({ request, count }) => ({ ids: ctx.queue.enqueue(request, count) }))
   handle('queue:cancel', ({ ids }) => {
     ctx.queue.cancel(ids)

--- a/src/main/queue/generation-queue.ts
+++ b/src/main/queue/generation-queue.ts
@@ -47,6 +47,27 @@ export class GenerationQueue extends EventEmitter {
     return ids
   }
 
+  /** Publish a batch only after its synchronous reservation commit succeeds. */
+  enqueueRequests(requests: GenerationRequest[], commit: () => void): string[] {
+    const entries = requests.map((request): QueueItem => ({
+      id: randomUUID(),
+      state: 'pending',
+      request
+    }))
+    try {
+      for (const item of entries) this.items.set(item.id, item)
+      commit()
+    } catch (error) {
+      for (const item of entries) this.items.delete(item.id)
+      throw error
+    }
+    if (entries.length > 0) {
+      this.emitChanged()
+      void this.run()
+    }
+    return entries.map((item) => item.id)
+  }
+
   cancel(ids: string[]): void {
     for (const id of ids) {
       const item = this.items.get(id)

--- a/src/main/scenes/repo.ts
+++ b/src/main/scenes/repo.ts
@@ -2,7 +2,9 @@ import { BrowserWindow, dialog } from 'electron'
 import { readFileSync, unlinkSync, writeFileSync } from 'fs'
 import { extname, isAbsolute, relative } from 'path'
 import JSZip from 'jszip'
-import type { Scene, SceneImage, ScenePreset } from '../../shared/types'
+import { planSceneReservations } from '../../shared/scene-request'
+import type { GenerationQueue } from '../queue/generation-queue'
+import type { IpcInvokeMap, Scene, SceneImage, ScenePreset } from '../../shared/types'
 import { getDb } from '../db'
 import { dropMemoryImage, isMemoryPath, libraryRoot } from '../images/storage'
 import { t } from '../i18n'
@@ -264,6 +266,34 @@ export function setReserveAll(presetId: number, count: number): void {
   getDb()
     .prepare('UPDATE gen_scenes SET reserve_count = ?, reserve_json = NULL WHERE preset_id = ?')
     .run(count, presetId)
+}
+
+/** No asynchronous boundary may separate the reservation snapshot and queue commit. */
+export function enqueueReservedScenes(
+  queue: GenerationQueue,
+  { casts, seedLocked }: IpcInvokeMap['scenes:enqueueReserved']['req']
+): string[] {
+  const db = getDb()
+  const rows = db
+    .prepare(
+      `
+    SELECT s.* FROM gen_scenes s
+    JOIN scene_presets p ON p.id = s.preset_id
+    WHERE s.reserve_count > 0
+    ORDER BY p.sort_order, p.id, s.sort_order, s.id
+  `
+    )
+    .all() as Row[]
+  const scenes = rows.map((row) => toScene({ ...row, image_count: 0 }))
+  const { requests, remaining } = planSceneReservations(scenes, casts, seedLocked, () =>
+    Math.floor(Math.random() * 4294967295)
+  )
+  return queue.enqueueRequests(
+    requests,
+    db.transaction(() => {
+      for (const [id, reserves] of remaining) setSceneReserves(id, reserves)
+    })
+  )
 }
 
 /** 모든 프리셋의 예약 총합 */

--- a/src/renderer/src/stores/scenes-store.ts
+++ b/src/renderer/src/stores/scenes-store.ts
@@ -1,10 +1,15 @@
 import { create } from 'zustand'
+import { applySceneRequest } from '@shared/scene-request'
+import { toast } from './toast-store'
 import { recordNav } from '../lib/nav-history'
 import type { GenerationRequest, Scene, SceneCast, SceneImage, ScenePreset } from '@shared/types'
 import { enabledCharacters, useCharactersStore } from './characters-store'
 import { randomSeed, useGenerationStore } from './generation-store'
 
+export { appendPrompt } from '@shared/scene-request'
+
 const PAGE = 80 // 씬 상세 이미지 페이지 크기 (수만 장 대비: 한 번에 전부 로드 금지)
+let reserving = false
 let loadSeq = 0 // load() 비동기 응답 순서 보장용
 let imagesSeq = 0 // loadImages() 비동기 응답 순서 보장용
 let selectionAnchor: number | null = null // 쉬프트 범위 선택 기준점 (마지막 일반 클릭 씬)
@@ -99,15 +104,6 @@ interface ScenesState {
   generateOne: (sceneId: number) => Promise<void>
 }
 
-/** 씬 프롬프트를 기본 프롬프트 뒤에 이어붙임 (콤마 정리) */
-export function appendPrompt(base: string, add: string): string {
-  const b = base.trim().replace(/,\s*$/, '')
-  const a = add.trim().replace(/^,\s*/, '')
-  if (!b) return a
-  if (!a) return b
-  return `${b}, ${a}`
-}
-
 /**
  * 출연의 캐릭터 카드 해석 — 출연이 있으면 그 카드들(enabled 무시),
  * 사이드바 출연(null)이면 켜둔 캐릭터. 삭제된 카드 id는 건너뛴다.
@@ -118,14 +114,10 @@ function resolveCharacters(cast: SceneCast | null): ReturnType<typeof enabledCha
   return cast.characterIds.map((id) => byId.get(id)).filter((c) => c != null)
 }
 
-/**
- * 씬 → 생성 요청. 사이드바의 모든 것(기본/네거 프롬프트·캐릭터·조각·바이브·레퍼런스·
- * 파라미터)을 그대로 쓰고, 씬 프롬프트는 기본/네거 프롬프트 "뒤에 이어붙인다".
- * 해상도만 씬 것을 사용 (소스가 있으면 소스 해상도가 우선). 바이브/레퍼런스/조각은
- * 메인 프로세스가 DB·와일드카드에서 읽어 적용하므로 여기선 프롬프트·캐릭터·파라미터만 구성.
- * 출연 예약이면 캐릭터/바이브/캐릭레퍼를 출연 구성으로 완전 교체 (사이드바 무시).
+/** Capture the renderer-owned parameters for one cast; scene fields are applied separately.
+ * Reference data and wildcard expansion keep their existing generation-time behavior.
  */
-function buildSceneRequest(scene: Scene, cast: SceneCast | null): GenerationRequest {
+function buildCastRequest(cast: SceneCast | null): GenerationRequest {
   const base = useGenerationStore.getState().request
   const src = useGenerationStore.getState().source
   // 3분할 꺼진 상태면 promptParts를 요청/메타데이터에 싣지 않는다
@@ -138,18 +130,12 @@ function buildSceneRequest(scene: Scene, cast: SceneCast | null): GenerationRequ
   }))
   return {
     ...base,
-    prompt: appendPrompt(base.prompt, scene.prompt),
-    promptParts:
-      splitEnabled && base.promptParts
-        ? { ...base.promptParts, detail: appendPrompt(base.promptParts.detail, scene.prompt) }
-        : undefined,
-    negativePrompt: appendPrompt(base.negativePrompt, scene.negativePrompt),
-    width: src ? src.width : scene.width,
-    height: src ? src.height : scene.height,
+    promptParts: splitEnabled ? base.promptParts : undefined,
+    width: src ? src.width : base.width,
+    height: src ? src.height : base.height,
     characterPrompts,
     // 출연 예약이면 바이브/캐릭레퍼도 출연 것으로 (빈 배열 = 없이 생성)
     ...(cast ? { vibeIds: cast.vibeIds, charRefIds: cast.charRefIds } : {}),
-    sceneId: scene.id,
     source: src
       ? {
           imageBase64: src.imageBase64,
@@ -479,42 +465,29 @@ export const useScenesStore = create<ScenesState>((set, get) => ({
   },
 
   generateReserved: async () => {
-    // 예약 = 생성 (1:1). 실행 순서는 출연별 묶음 — 사이드바 예약 전부 → 출연1 예약 전부 → …
-    // (프리셋 순서는 그 안에서 유지). 예약을 큐에 넣는 즉시 소진(0).
-    const castOrder = ['', ...get().casts.map((c) => c.id)]
-    const castById = new Map(get().casts.map((c) => [c.id, c]))
-
-    // 프리셋별 예약 씬 수집 + 소진
-    const reservedScenes: Scene[] = []
-    for (const preset of get().presets) {
-      const { items } = await window.nais.invoke('scenes:list', { presetId: preset.id })
-      const reserved = items.filter((s) => s.reserveCount > 0)
-      if (reserved.length === 0) continue
-      if (preset.id === get().activePresetId) {
-        set({
-          scenes: get().scenes.map((s) =>
-            s.reserveCount > 0 ? { ...s, reserveCount: 0, reserves: {} } : s
-          )
-        })
-      }
-      void window.nais.invoke('scenes:setReserveAll', { presetId: preset.id, count: 0 })
-      reservedScenes.push(...reserved)
-    }
-
-    for (const castId of castOrder) {
-      const cast = castId === '' ? null : (castById.get(castId) ?? null)
-      if (castId !== '' && !cast) continue // 삭제된 출연의 예약은 건너뜀
-      for (const scene of reservedScenes) {
-        const count = scene.reserves[castId] ?? 0
-        for (let i = 0; i < count; i++) {
-          await window.nais.invoke('queue:enqueue', {
-            request: { ...buildSceneRequest(scene, cast), seed: sceneSeed(i) },
-            count: 1
-          })
-        }
+    if (reserving) return
+    reserving = true
+    try {
+      // Capture all renderer-owned settings before the first asynchronous boundary.
+      const casts = [null, ...get().casts].map((cast) => ({
+        castId: cast?.id ?? '',
+        request: buildCastRequest(cast)
+      }))
+      await window.nais.invoke('scenes:enqueueReserved', {
+        casts,
+        seedLocked: useGenerationStore.getState().seedLocked
+      })
+    } catch (error) {
+      toast(error instanceof Error ? error.message : String(error), 'error')
+    } finally {
+      try {
+        await Promise.all([get().load(), get().refreshReservedTotal()])
+      } catch (error) {
+        toast(error instanceof Error ? error.message : String(error), 'error')
+      } finally {
+        reserving = false
       }
     }
-    set({ reservedTotal: 0 })
   },
 
   generateOne: async (sceneId) => {
@@ -524,7 +497,7 @@ export const useScenesStore = create<ScenesState>((set, get) => ({
     const castId = get().activeCastId
     const cast = castId === '' ? null : (get().casts.find((c) => c.id === castId) ?? null)
     await window.nais.invoke('queue:enqueue', {
-      request: { ...buildSceneRequest(scene, cast), seed: sceneSeed(0) },
+      request: { ...applySceneRequest(buildCastRequest(cast), scene), seed: sceneSeed(0) },
       count: 1
     })
   },

--- a/src/shared/scene-request.ts
+++ b/src/shared/scene-request.ts
@@ -1,0 +1,55 @@
+import type { GenerationRequest, Scene } from './types'
+
+export function appendPrompt(base: string, add: string): string {
+  const b = base.trim().replace(/,\s*$/, '')
+  const a = add.trim().replace(/^,\s*/, '')
+  if (!b) return a
+  if (!a) return b
+  return `${b}, ${a}`
+}
+
+export function applySceneRequest(
+  base: GenerationRequest,
+  scene: Pick<Scene, 'id' | 'prompt' | 'negativePrompt' | 'width' | 'height'>
+): GenerationRequest {
+  return {
+    ...base,
+    prompt: appendPrompt(base.prompt, scene.prompt),
+    negativePrompt: appendPrompt(base.negativePrompt, scene.negativePrompt),
+    promptParts: base.promptParts
+      ? { ...base.promptParts, detail: appendPrompt(base.promptParts.detail, scene.prompt) }
+      : undefined,
+    width: base.source ? base.width : scene.width,
+    height: base.source ? base.height : scene.height,
+    sceneId: scene.id
+  }
+}
+
+/** Preserve cast-major ordering and reset the locked seed offset for each scene. */
+export function planSceneReservations(
+  scenes: Scene[],
+  casts: { castId: string; request: GenerationRequest }[],
+  seedLocked: boolean,
+  randomSeed: () => number
+): { requests: GenerationRequest[]; remaining: Map<number, Record<string, number>> } {
+  const requests: GenerationRequest[] = []
+  const remaining = new Map(scenes.map((scene) => [scene.id, { ...scene.reserves }]))
+  const seen = new Set<string>()
+  for (const { castId, request } of casts) {
+    if (seen.has(castId)) throw new Error('Duplicate reservation cast')
+    seen.add(castId)
+    for (const scene of scenes) {
+      const count = scene.reserves[castId] ?? 0
+      if (!Number.isSafeInteger(count) || count < 0) throw new Error('Invalid reservation count')
+      const base = applySceneRequest(request, scene)
+      for (let i = 0; i < count; i++) {
+        requests.push({
+          ...base,
+          seed: seedLocked && request.seed >= 0 ? (request.seed + i) % 4294967296 : randomSeed()
+        })
+      }
+      delete remaining.get(scene.id)![castId]
+    }
+  }
+  return { requests, remaining }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -422,6 +422,10 @@ export interface IpcInvokeMap {
     }
   }
   'nai:anlasUsage': { req: void; res: { today: number; week: number } }
+  'scenes:enqueueReserved': {
+    req: { casts: { castId: string; request: GenerationRequest }[]; seedLocked: boolean }
+    res: { ids: string[] }
+  }
   'queue:enqueue': { req: { request: GenerationRequest; count: number }; res: { ids: string[] } }
   'queue:cancel': { req: { ids: string[] }; res: void }
   'queue:status': { req: void; res: QueueStatus }

--- a/tests/scene-reservations.test.ts
+++ b/tests/scene-reservations.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applySceneRequest, planSceneReservations } from '../src/shared/scene-request'
+import { GenerationQueue } from '../src/main/queue/generation-queue'
+import type { GenerationRequest, Scene } from '../src/shared/types'
+
+const request = {
+  prompt: 'base, ',
+  negativePrompt: 'bad',
+  width: 832,
+  height: 1216,
+  seed: 4294967295,
+  promptParts: { detail: 'detail' }
+} as GenerationRequest
+const scene = (id: number, reserves: Record<string, number>): Scene =>
+  ({
+    id,
+    prompt: ', scene',
+    negativePrompt: 'worse',
+    width: 1024,
+    height: 1024,
+    reserves
+  }) as Scene
+
+describe('scene reservation handoff', () => {
+  it('keeps cast and scene order, locked seed wrapping, and unmatched reservations', () => {
+    const scenes = [scene(2, { '': 2, cast: 1, deleted: 3 }), scene(1, { '': 1 })]
+    const plan = planSceneReservations(
+      scenes,
+      [
+        { castId: '', request },
+        { castId: 'cast', request: { ...request, prompt: 'cast' } }
+      ],
+      true,
+      () => 7
+    )
+    expect(plan.requests.map((r) => [r.sceneId, r.seed, r.prompt])).toEqual([
+      [2, 4294967295, 'base, scene'],
+      [2, 0, 'base, scene'],
+      [1, 4294967295, 'base, scene'],
+      [2, 4294967295, 'cast, scene']
+    ])
+    expect(plan.remaining.get(2)).toEqual({ deleted: 3 })
+    expect(plan.remaining.get(1)).toEqual({})
+    expect(scenes[0].reserves).toEqual({ '': 2, cast: 1, deleted: 3 })
+    expect(plan.requests[0].promptParts?.detail).toBe('detail, scene')
+    expect(plan.requests[0].negativePrompt).toBe('bad, worse')
+  })
+
+  it('keeps source resolution and chooses a fresh random seed per image when unlocked', () => {
+    const source = { ...request, source: { imageBase64: 'image' } } as GenerationRequest
+    expect(applySceneRequest(source, scene(1, {}))).toMatchObject({ width: 832, height: 1216 })
+    expect(applySceneRequest(request, scene(1, {}))).toMatchObject({ width: 1024, height: 1024 })
+    const random = vi.fn().mockReturnValueOnce(9).mockReturnValueOnce(10)
+    expect(
+      planSceneReservations(
+        [scene(1, { '': 2 })],
+        [{ castId: '', request }],
+        false,
+        random
+      ).requests.map((r) => r.seed)
+    ).toEqual([9, 10])
+  })
+
+  it('does not publish or start a batch when the reservation transaction fails', () => {
+    const generate = vi.fn(async () => '/image.png')
+    const queue = new GenerationQueue(generate)
+    const changed = vi.fn()
+    queue.on('changed', changed)
+    expect(() =>
+      queue.enqueueRequests([request, request], () => {
+        throw new Error('database full')
+      })
+    ).toThrow('database full')
+    expect(queue.status().items).toEqual([])
+    expect(changed).not.toHaveBeenCalled()
+    expect(generate).not.toHaveBeenCalled()
+  })
+
+  it('starts only after commit and a second handoff cannot replay consumed reservations', async () => {
+    let committed = false
+    const generate = vi.fn(async () => {
+      expect(committed).toBe(true)
+      return '/image.png'
+    })
+    const queue = new GenerationQueue(generate)
+    const scenes = [scene(1, { '': 1 })]
+    const casts = [{ castId: '', request }]
+    const first = planSceneReservations(scenes, casts, true, () => 1)
+    const ids = queue.enqueueRequests(first.requests, () => {
+      scenes[0].reserves = first.remaining.get(1)!
+      committed = true
+    })
+    const second = planSceneReservations(scenes, casts, true, () => 1)
+    expect(queue.enqueueRequests(second.requests, () => {})).toEqual([])
+    await vi.waitFor(() => expect(queue.status().items[0].state).toBe('done'))
+    expect(ids).toHaveLength(1)
+    expect(generate).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects duplicate casts and invalid counts without changing reservations', () => {
+    const casts = [
+      { castId: '', request },
+      { castId: '', request }
+    ]
+    expect(() => planSceneReservations([scene(1, { '': 1 })], casts, true, () => 0)).toThrow(
+      'Duplicate'
+    )
+    expect(() =>
+      planSceneReservations([scene(1, { '': 1.5 })], casts.slice(0, 1), true, () => 0)
+    ).toThrow('Invalid')
+  })
+})


### PR DESCRIPTION
## Summary

Scene reservations were cleared before the renderer submitted individual queue requests, so a renderer reload or interrupted submission could discard work that had never reached the queue. Submit the reservation handoff through one main-process IPC call, and publish/start the prepared queue batch only after the reservation transaction commits. If that transaction fails, remove the prepared queue entries without starting generation.

Capture renderer-owned request settings before submission, preserve cast-major ordering and existing seed rules, and refresh reservation counts from the database after the handoff. Only submitted casts are consumed; unmatched reservations remain intact. Wildcard expansion and reference loading retain their existing generation-time behavior.

## Validation

- Focused Node unit tests: 9 passed across scene reservations and generation queue suites
- TypeScript checks passed
- ESLint passed for changed files
- `git diff --check upstream/main...HEAD` passed
- Electron runtime and packaging were not exercised

The generation queue remains in memory; this change does not add recovery after a main-process crash or application exit.
